### PR TITLE
Warn isapprox with zero and fix display of Gurobi tip

### DIFF
--- a/getting_started_with_julia.ipynb
+++ b/getting_started_with_julia.ipynb
@@ -391,7 +391,40 @@
     "    optimization models. A common mistake you're likely to make is checking\n",
     "    whether a binary variable is 0 using `value(z) == 0`. Always remember to\n",
     "    use something like `isapprox` when comparing floating point numbers.\n",
-    "\n",
+    "    Note that `isapprox` will always return `false` if one of the number being\n",
+    "    compared is `0` and `atol` is zero (its default value)."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "1e-300 ≈ 0.0"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "so always set a nonzero value of `atol` if one of the arguments can be zero."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "isapprox(1e-9, 0.0, atol=1e-8)"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "**Tip**\n",
     "    Gurobi has a [good series of articles](https://www.gurobi.com/documentation/9.0/refman/num_grb_guidelines_for_num.html)\n",
     "    on the implications of floating point in optimization if you want to read\n",
     "    more."

--- a/src/getting_started_with_julia.jl
+++ b/src/getting_started_with_julia.jl
@@ -164,7 +164,16 @@ isapprox(sin(2π / 3), √3 / 2; atol = 1e-8)
 #     optimization models. A common mistake you're likely to make is checking
 #     whether a binary variable is 0 using `value(z) == 0`. Always remember to
 #     use something like `isapprox` when comparing floating point numbers.
-#
+#     Note that `isapprox` will always return `false` if one of the number being
+#     compared is `0` and `atol` is zero (its default value).
+
+1e-300 ≈ 0.0
+
+# so always set a nonzero value of `atol` if one of the arguments can be zero.
+
+isapprox(1e-9, 0.0, atol=1e-8)
+
+# !!! tip
 #     Gurobi has a [good series of articles](https://www.gurobi.com/documentation/9.0/refman/num_grb_guidelines_for_num.html)
 #     on the implications of floating point in optimization if you want to read
 #     more.


### PR DESCRIPTION
This branch is based on https://github.com/odow/jump-training-materials/pull/3, merge that one first.

The Gurobi paragraph was displayed as code in the notebook because of the 4-chars indent.
It is recommeded in the warning to use `isapprox` for comparing with zero so I'd prefer warning that `atol` should be nonzero in this case. This is the classical pitfall with `isapprox`.